### PR TITLE
fix: auto-inject content script to resolve connection errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,11 @@ This project is open source and available under the MIT License.
 - ✅ Enhanced error handling and logging
 - ✅ Updated all documentation
 
+### v2.0.4 (2025-12-16)
+- ✅ Added auto-injection of content script to fix "Connection failed" errors after updates
+- ✅ Added `scripting` permission to manifest for robust script injection
+- ✅ Improved error handling in popup
+
 ### v2.0.3 (2025-12-16)
 - ✅ Added support for Google Gemini (`gemini.google.com`) to extract and save conversations
 - ✅ Use `Gemini_Conversation_YYYY-MM-DD.txt` filename when saving from Gemini

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 3,
   "name": "ChatGPT Chat Saver",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Save ChatGPT and Gemini conversations as text files with robust message detection",
-  "permissions": ["tabs"],
+  "permissions": ["tabs", "scripting"],
   "host_permissions": [
     "https://chat.openai.com/*",
     "https://chatgpt.com/*",


### PR DESCRIPTION
Adds scripting permission and fallback logic in popup.js to inject content.js if it's missing. This fixes 'Connection failed' errors after extension updates or on pages where the script failed to load initially.